### PR TITLE
Change order of -ss and -i flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ffmpeg -i input.mov -acodec pcm_s16le -ac 2 output.wav
 Extracts a clip from the input video file.
 
 ```
-ffmpeg -i input.mov -ss START_SECS -c copy -t CLIP_LENGTH output.mov
+ffmpeg -ss START_SECS -i input.mov -c copy -t CLIP_LENGTH output.mov
 ```
 
 You can also transcode at the same time by changing the extension of the output file.


### PR DESCRIPTION
Updates cookbook to use the **MUCH** faster order of options to extract a clip from a video file.

See https://trac.ffmpeg.org/wiki/Seeking for more information on seeking with FFMPEG. Using `-ss` before an input will ensure that FFMPEG jumps to the given timestamp and then start decoding. If the `-ss` is after the input then FFMPEG will start decoding and discarding the given input up until the point that the timestamp is hit.

Using a 4 minute long clip you can see the order can double the amount of time it takes, it only gets faster the larger the clip you use, depending on how far through the video you decide to extract. For example, an hour long clip where you want to extract the last 10 minutes will see a HUGE improvement, whereas a 10 hour clip where you extract the first 10 minutes will see next to no improvement.

```
ffmpeg -i kennyg.mp4 -ss 03:50 -t 10 output.mp4  16.50s
ffmpeg -ss 03:50 -i kennyg.mp4 -t 10 output.mp4  7.14s
```

This changed my life.